### PR TITLE
Fix running as a service with config

### DIFF
--- a/cmd/defnodo/main.go
+++ b/cmd/defnodo/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"log"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/ismarc/defnodo/internal/app"
@@ -213,6 +214,10 @@ func loadGlobalOptions(c *cli.Context) (result *GlobalConfig, err error) {
 
 	serviceOptions := make(service.KeyValue)
 	serviceOptions["UserService"] = true
+	configLocation, err := filepath.Abs(c.String("config"))
+	if err != nil {
+		return
+	}
 	serviceConfig := &service.Config{
 		Name:        "defnodo",
 		DisplayName: "DefNoDo",
@@ -220,7 +225,7 @@ func loadGlobalOptions(c *cli.Context) (result *GlobalConfig, err error) {
 		Option:      serviceOptions,
 		Arguments: []string{
 			"-c",
-			c.String("config"),
+			configLocation,
 			"run",
 			"--service",
 		},

--- a/examples/defnodo-config.yaml
+++ b/examples/defnodo-config.yaml
@@ -6,7 +6,7 @@ volume-mounts:
   - /Users/mbrace/dev
 # Path to daemon.json to use for docker.
 # Default: {}
-docker-daemon.json: examples/daemon.json
+docker-daemon.json: daemon.json
 # Directory containing VM image and to use for associated
 # data and sockets
 data-directory: defnodo-data

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -57,16 +57,17 @@ func (defnodo *DefNoDo) Run() (err error) {
 	linuxkitPath := filepath.Join(exPath, "linuxkit")
 	log.Printf("linuxkit path: %s\n", linuxkitPath)
 
-	dataFile, err := defnodo.generateMetadata(".")
+	runLocation := defnodo.config.DataDirectory
+	if !strings.HasPrefix(runLocation, "/") {
+		runLocation = filepath.Join(exPath, "..", defnodo.config.DataDirectory)
+	}
+
+	dataFile, err := defnodo.generateMetadata(runLocation)
 	if err != nil {
 		log.Fatal(err)
 	}
 	defer os.Remove(dataFile)
 
-	runLocation := defnodo.config.DataDirectory
-	if !strings.HasPrefix(runLocation, "/") {
-		runLocation = filepath.Join(exPath, "..", defnodo.config.DataDirectory)
-	}
 	// See scripts/run_vm.sh for example run command
 	cmd := exec.Command(linuxkitPath,
 		"run", "hyperkit",
@@ -80,7 +81,7 @@ func (defnodo *DefNoDo) Run() (err error) {
 		"-vsock-ports", "2376",
 		"-squashfs",
 		"-data-file", dataFile,
-		filepath.Join(defnodo.config.DataDirectory, "defnodo"))
+		filepath.Join(runLocation, "defnodo"))
 
 	cmd.Env = os.Environ()
 

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -11,12 +11,13 @@ import (
 
 // Config is the runtime configuration
 type Config struct {
-	DataDirectory    string   `yaml:"data-directory"`
-	VolumeMounts     []string `yaml:"volume-mounts"`
-	DockerDaemonJson string   `default:"" yaml:"docker-daemon.json"`
-	VM               VMConfig `yaml:"vm"`
-	IsService        bool     `default:"false"`
-	Interactive      bool     `default:"false"`
+	DataDirectory       string   `yaml:"data-directory"`
+	VolumeMounts        []string `yaml:"volume-mounts"`
+	DockerDaemonJson    string   `default:"" yaml:"docker-daemon.json"`
+	VM                  VMConfig `yaml:"vm"`
+	IsService           bool     `default:"false"`
+	Interactive         bool     `default:"false"`
+	ConfigBaseDirectory string
 }
 
 type VMConfig struct {
@@ -53,7 +54,14 @@ func LoadConfig(location string) (config *Config, err error) {
 	} else {
 		log.Printf("No config found, using all defaults...\n")
 	}
+
 	defaults.Set(config)
+
+	configDir, err := filepath.Abs(filepath.Dir(location))
+	if err != nil {
+		return
+	}
+	config.ConfigBaseDirectory = configDir
 	return
 }
 

--- a/internal/app/metadata.go
+++ b/internal/app/metadata.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 )
 
@@ -37,12 +38,13 @@ func (defnodo *DefNoDo) generateMetadata(directory string) (filename string, err
 	// Read any specified daemon.json
 	daemon_json := "{}"
 	if defnodo.config.DockerDaemonJson != "" {
-		daemon, err := os.ReadFile(defnodo.config.DockerDaemonJson)
+		daemon_location := filepath.Join(defnodo.config.ConfigBaseDirectory, defnodo.config.DockerDaemonJson)
+		daemon, err := os.ReadFile(daemon_location)
 		if err != nil {
 			return filename, err
 		}
 		if !json.Valid(daemon) {
-			msg := fmt.Sprintf("%s does not contain valid JSON: \n%s\n", defnodo.config.DockerDaemonJson, string(daemon))
+			msg := fmt.Sprintf("%s does not contain valid JSON: \n%s\n", daemon_location, string(daemon))
 			err = errors.New(msg)
 			return filename, err
 		}


### PR DESCRIPTION
For some reason, when files are copied to a different directory and run from there, the service hangs halfway-ish through startup.  It looks related to maybe vmnet or vpnkit, and happens a majority of the time.  But it's 100% reliable when run form the build directory.  All paths look fine, and starting the service with the exact same parameters works 100% of the time.

Other than that, this fixes the needed paths and file locations/relationships with the recent config changes.